### PR TITLE
Add `scanner.c` to sources in `ext_modules`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
             sources=[
                 "bindings/python/tree_sitter_matlab/binding.c",
                 "src/parser.c",
-                # NOTE: if your language uses an external scanner, add it here.
+                "src/scanner.c"
             ],
             extra_compile_args=[
                 "-std=c11",


### PR DESCRIPTION
Currently the python bindings when installed via `pip install -e .` in the root of the repo cause a failure when importing the package:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/anton/tools/matlabdomain/venv/lib/python3.10/site-packages/tree_sitter_matlab/__init__.py", line 3, in <module>
    from ._binding import language
ImportError: /home/anton/tools/matlabdomain/venv/lib/python3.10/site-packages/tree_sitter_matlab/_binding.abi3.so: undefined symbol: tree_sitter_matlab_external_scanner_create
```

This is due to the scanner not being included in the sources that are included in package. 