### PR TITLE
fix: SPM compatibility for Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,12 +1,6 @@
 // swift-tools-version:5.3
 
-import Foundation
 import PackageDescription
-
-var sources = ["src/parser.c"]
-if FileManager.default.fileExists(atPath: "src/scanner.c") {
-    sources.append("src/scanner.c")
-}
 
 let package = Package(
     name: "TreeSitterMatlab",
@@ -21,7 +15,7 @@ let package = Package(
             name: "TreeSitterMatlab",
             dependencies: [],
             path: ".",
-            sources: sources,
+            sources: ["src/parser.c", "src/scanner.c"],
             resources: [
                 .copy("queries")
             ],
@@ -31,7 +25,7 @@ let package = Package(
         .testTarget(
             name: "TreeSitterMatlabTests",
             dependencies: [
-                "SwiftTreeSitter",
+                .product(name: "SwiftTreeSitter", package: "swift-tree-sitter"),
                 "TreeSitterMatlab",
             ],
             path: "bindings/swift/TreeSitterMatlabTests"


### PR DESCRIPTION
## Summary

Fixes two issues preventing this package from being used as an SPM dependency:

- **FileManager.fileExists()** returns `false` in SPM's sandboxed environment, excluding `scanner.c` and causing build failures with undefined symbols. Fixed by using a static source list.
- **Test target dependency** used bare string `"SwiftTreeSitter"` which fails because SPM requires explicit product references when package identity differs from product name. Fixed with `.product(name:package:)` syntax.

## Test plan

- [x] Verified `swift package resolve` succeeds when added as dependency
- [x] Verified `swift build` succeeds (scanner symbols resolved)

Fixes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)